### PR TITLE
Make 'make lint' generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,29 +5,21 @@ app_name=adminly_dashboard
 build_directory=$(CURDIR)/build
 temp_build_directory=$(build_directory)/temp
 build_tools_directory=$(CURDIR)/build/tools
-composer=$(shell which composer 2> /dev/null)
 
 all: dev-setup lint build-js-production test
 
 release: npm-init build-js-production build-tarball
-# Dev env management
+
 dev-setup: clean clean-dev composer npm-init
 
+lint: eslint stylelint prettier
 
-# Installs and updates the composer dependencies. If composer is not installed
-# a copy is fetched from the web
+lint-fix: eslint-fix stylelint-fix prettier-fix
+
+# Dependencies
 composer:
-ifeq (, $(composer))
-	@echo "No composer command available, downloading a copy from the web"
-	mkdir -p $(build_tools_directory)
-	curl -sS https://getcomposer.org/installer | php
-	mv composer.phar $(build_tools_directory)
-	php $(build_tools_directory)/composer.phar install --prefer-dist
-	php $(build_tools_directory)/composer.phar update --prefer-dist
-else
 	composer install --prefer-dist
 	composer update --prefer-dist
-endif
 
 npm-init:
 	npm ci
@@ -49,11 +41,11 @@ serve-js:
 	npm run serve
 
 # Linting
-lint:
-	npm run lint
+eslint:
+	npm run eslint
 
-lint-fix:
-	npm run lint:fix
+eslint-fix:
+	npm run eslint:fix
 
 # Style linting
 stylelint:
@@ -61,6 +53,13 @@ stylelint:
 
 stylelint-fix:
 	npm run stylelint:fix
+
+# Prettier
+prettier:
+	npm run prettier
+
+prettier-fix:
+	npm run prettier:fix
 
 # Cleaning
 clean:

--- a/package.json
+++ b/package.json
@@ -45,10 +45,12 @@
 		"dev": "webpack --node-env development --progress",
 		"watch": "webpack --node-env development --progress --watch",
 		"serve": "webpack --node-env development serve --progress",
-		"lint": "eslint --ext .js,.vue src",
-		"lint:fix": "eslint --ext .js,.vue src --fix",
+		"eslint": "eslint --ext .js,.vue src",
+		"eslint:fix": "eslint --ext .js,.vue src --fix",
 		"stylelint": "stylelint css/*.css css/*.scss src/**/*.scss src/**/*.vue",
-		"stylelint:fix": "stylelint css/*.css css/*.scss src/**/*.scss src/**/*.vue --fix"
+		"stylelint:fix": "stylelint css/*.css css/*.scss src/**/*.scss src/**/*.vue --fix",
+		"prettier": "prettier --check .",
+		"prettier:fix": "prettier --write ."
 	},
 	"dependencies": {
 		"@nextcloud/axios": "^1.9.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,24 +5,23 @@
 			<p>It's good to see you again!</p>
 		</div>
 
-		<div class="calendar-widget centered large-text">
-			Calendar
-		</div>
-		<div class="events-widget centered large-text">
-			Events
-		</div>
-		<div class="booking-widget centered large-text">
-			Create Booking
-		</div>
+		<div class="calendar-widget centered large-text">Calendar</div>
+		<div class="events-widget centered large-text">Events</div>
+		<div class="booking-widget centered large-text">Create Booking</div>
 	</main>
 </template>
 
 <script>
 export default {
-	name: 'App',
+	name: "App",
 	data() {
 		return {
-			message: 'Hello ' + document.querySelector('head').getAttribute('data-user-displayname') + '!',
+			message:
+				"Hello " +
+				document
+					.querySelector("head")
+					.getAttribute("data-user-displayname") +
+				"!",
 		};
 	},
 };

--- a/src/main.js
+++ b/src/main.js
@@ -19,15 +19,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { generateFilePath } from '@nextcloud/router';
+import { generateFilePath } from "@nextcloud/router";
 
-import Vue from 'vue';
-import App from './App';
+import Vue from "vue";
+import App from "./App";
 
 // eslint-disable-next-line
 __webpack_public_path__ = generateFilePath("adminly_dashboard", "", "js/");
 
 export default new Vue({
-	el: '#app',
+	el: "#app",
 	render: (h) => h(App),
 });


### PR DESCRIPTION
This is a pull request suggestion to make 'make lint' generic and have it run eslint, stylelint and prettier.

I've also removed the automatic download of composer from the makefile, as I'm not a fan of just pulling down a script and directly executing it if composer isn't found. I personally wouldn't call it best practice and folks should also be able to get composer installed on their own.

I've also run the linting on all files and made the needed changes to make all three tools happy.