### PR TITLE
Prerelease 0.1.0-alpha2

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>Dashboard</name>
     <summary><![CDATA[Adminly Dashboard]]></summary>
     <description><![CDATA[Adminly Dashboard]]></description>
-    <version>0.1.0</version>
+    <version>0.1.0-alpha2</version>
     <licence>agpl</licence>
     <author>MetaProvide</author>
     <namespace>Adminly_Dashboard</namespace>
@@ -23,5 +23,4 @@
         <order>-1</order>
       </navigation>
 	</navigations>
-
 </info>


### PR DESCRIPTION
Bump version number to 0.1.0-alpha2. Technically alpha1 has already been released but I forgot to bump the version number.