### PR TITLE
remove price

### DIFF
--- a/src/components/UpcomingEventCard.vue
+++ b/src/components/UpcomingEventCard.vue
@@ -15,41 +15,6 @@
 			</div>
 			<span class="text">{{ participantsText }}</span>
 		</div>
-		<div v-if="Math.random() > 0.5" class="row">
-			<svg
-				width="24"
-				height="24"
-				viewBox="0 0 23 23"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<circle cx="11.5" cy="11.5" r="11.5" fill="#6295E2" />
-				<path
-					d="M16.2453 6.13281L10.0894 14.2489L6.44987 10.612L4.77051 12.2914L10.3675 17.8884L18.2054 7.81218L16.2453 6.13281Z"
-					fill="white"
-				/>
-			</svg>
-
-			<span class="text">Payment Done</span>
-		</div>
-		<div v-else class="row">
-			<svg
-				width="23"
-				height="23"
-				viewBox="0 0 23 23"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<circle
-					cx="11.5"
-					cy="11.5"
-					r="10.5"
-					stroke="#6295E2"
-					stroke-width="2"
-				/>
-			</svg>
-			<span class="text">Not Paid Yet</span>
-		</div>
 		<div v-if="isPrimary" class="column title">
 			<h4>Description</h4>
 			<p
@@ -118,12 +83,6 @@ export default {
 			type: Array,
 			default() {
 				return [];
-			},
-		},
-		hasPaid: {
-			type: Boolean,
-			default() {
-				return false;
 			},
 		},
 		descriptionTitle: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,6 +43,7 @@ export const EventUtil = {
 		return url;
 	},
 	fetchCalendarEvents: async (user, calendarName, fromDate, endDate) => {
+
 		const url = EventUtil.getApiUrl(user, calendarName, fromDate, endDate);
 		return axios
 			.get(url)

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,6 @@ export const EventUtil = {
 		return url;
 	},
 	fetchCalendarEvents: async (user, calendarName, fromDate, endDate) => {
-
 		const url = EventUtil.getApiUrl(user, calendarName, fromDate, endDate);
 		return axios
 			.get(url)


### PR DESCRIPTION
Price component from UpcomingEvent has been removed.

Two tasks has been noted but not handled on this PR.

1. I have noticed a layout issue when the event is upcoming tomorrow.

<img width="252" alt="image" src="https://user-images.githubusercontent.com/3958329/172720619-a8734c8a-25ba-47db-86d1-399e34348b10.png">
I think we need to know what Joao thinks is the best way to make it look better. I think one line is preferable but perhaps we can use icons for 'Today' and 'Tomorrow'.

2. Also strange behavoir when changing the api parameters for fetching events.
The issue we have is when creating one event in the calendar one hour from now it will not show in the upcoming events feed. 

The api endpoint looks like this: `/remote.php/dav/calendars/${userName}/${calendarName}?export&expand=1&accept=jcal&componentType=VEVENT&start=${fromDate}&end=${endDate}`

I assume that the `fromDate` is not correct so I tried to adjust it with one hour back in time
 like this: `/remote.php/dav/calendars/${userName}/${calendarName}?export&expand=1&accept=jcal&componentType=VEVENT&start=${fromDate - 60*60*1}&end=${endDate}`

Now suddenly all events are showing but also events that has happened more than one hour ago.