### PR TITLE
Style/final calendar widget layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,11 +9,12 @@
 			<Newsfeed :news="sortedNews" />
 		</div>
 		<div class="booking-widget">
-			<h2>BOOK APPOINTMENT</h2>
 			<Calendar
 				:events="calendarEvents"
 				:change-pane="handleFetchCalendarEvents"
 			/>
+			<div class="separator-line"></div>
+			<h2 class="temporary-header-adjustment">BOOK APPOINTMENT</h2>
 			<Booking :booking-form-url="bookingFormUrl" />
 		</div>
 	</main>
@@ -148,12 +149,29 @@ h2 {
 	text-align: center;
 }
 
+.separator-line {
+	height: 0px;
+	width: 65%;
+	border: none;
+	border-top: 1.2px solid rgba(216, 216, 216, 0.44);
+}
+
+/* Used since iframe has built in margin */
+.temporary-header-adjustment {
+	position: relative;
+	top: 25px;
+}
+
 .newsfeed-widget {
 	grid-column-start: 2;
 	grid-column-end: 3;
 }
 
 .booking-widget {
+	margin-right: 12px;
+	box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+	border-radius: 16px;
+	padding-top: 24px;
 	grid-column-start: 3;
 	grid-column-end: 4;
 	display: flex;

--- a/src/App.vue
+++ b/src/App.vue
@@ -133,7 +133,7 @@ main {
 }
 
 .events-widget {
-	max-width: 390px;
+	width: 390px;
 	height: calc(100% - 70px);
 	grid-column-start: 1;
 	grid-column-end: 2;
@@ -177,11 +177,6 @@ h2 {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	/* Use style below to make fixed */
-	/* TODO: adjust calendar & booking component to Figma Design */
-	/* position: fixed;
-	top: 70px;
-	left: calc(100% - 440px); */
 }
 
 main a {

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -93,6 +93,10 @@ export default {
 	}
 
 	.datepicker-body {
+		.datepicker-dateRange-item-active {
+			border-radius: 8px;
+		}
+
 		span {
 			width: 45px;
 			height: 45px;
@@ -102,9 +106,12 @@ export default {
 		}
 
 		span div {
-			height: 0;
+			transform: translate(0, 25%);
 		}
 
+		span div div {
+			height: 0;
+		}
 		// .event-indicator {
 		// 	background-color: rgb(206, 182, 117);
 		// 	position: relative;

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -1,6 +1,6 @@
 <template>
-		<div>
-		<h3 class="today-text">{{todayText}}</h3>
+	<div>
+		<h3 class="today-text">{{ todayText }}</h3>
 		<SlotCalendar
 			v-model="value"
 			:disabled-days-of-week="disabled"
@@ -19,10 +19,9 @@
 				v-for="(evt, idx) in events"
 				:key="idx"
 				:slot="evt.dtstart.slice(0, 10)"
-				class="event-indicator"
 			></div>
 		</SlotCalendar>
-		</div>
+	</div>
 </template>
 
 <script>
@@ -65,11 +64,40 @@ export default {
 		todayText() {
 			const today = dayjs();
 			return `Today, ${today.format("D MMMM YYYY")}`;
-		}
+		},
+	},
+	updated() {
+		this.applyDateStyling();
 	},
 	methods: {
 		redirectToCalendar(e) {
 			window.location.href = "/apps/calendar/dayGridMonth/now";
+		},
+		mod(a, n) {
+			return a - n * Math.floor(a / n);
+		},
+		applyDateStyling() {
+			const today = dayjs();
+			const currentDayIndex = this.mod(today.day() - 1, 6); // because monday should be index 0
+
+			document
+				.querySelector(".datepicker-weekRange")
+				.childNodes.forEach((daySpan, idx) => {
+					daySpan.style.fontWeight =
+						currentDayIndex === idx ? 900 : 500;
+				});
+
+			document.querySelectorAll(".day-cell").forEach((day) => {
+				if (
+					this.events.some(
+						(evt) =>
+							dayjs(evt.dtstart).date() === Number(day.innerText)
+					)
+				) {
+					day.style.color = "#F68500";
+					day.style.fontWeight = 600;
+				}
+			});
 		},
 	},
 };
@@ -83,7 +111,6 @@ export default {
 }
 
 .event-calendar {
-
 	.datepicker-popup {
 		box-shadow: none;
 	}
@@ -94,15 +121,14 @@ export default {
 
 	.datepicker-body {
 		.datepicker-dateRange-item-active {
-			border-radius: 8px;
+			border-radius: 14px;
+			border: 3px solid white;
+			outline: thin solid #3276b1;
 		}
 
 		span {
 			width: 45px;
 			height: 45px;
-			// display: flex;
-			// justify-content: center;
-			// align-items: center;
 		}
 
 		span div {
@@ -112,24 +138,6 @@ export default {
 		span div div {
 			height: 0;
 		}
-		// .event-indicator {
-		// 	background-color: rgb(206, 182, 117);
-		// 	position: relative;
-		// 	top: 5px;
-		// 	margin: 0 auto;
-		// 	width: 10px;
-		// 	height: 10px;
-		// 	border-radius: 50%;
-		// 	cursor: pointer;
-		// }
-
-		// .datepicker-monthRange span {
-		// 	width: 100px;
-		// 	height: 100px;
-		// 	vertical-align: middle;
-		// 	line-height: 100px;
-		// 	// font-weight: 600;
-		// }
 	}
 }
 </style>

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -1,5 +1,6 @@
 <template>
-	<div style="height: 500px">
+		<div>
+		<h3 class="today-text">{{todayText}}</h3>
 		<SlotCalendar
 			v-model="value"
 			:disabled-days-of-week="disabled"
@@ -21,11 +22,13 @@
 				class="event-indicator"
 			></div>
 		</SlotCalendar>
-	</div>
+		</div>
 </template>
 
 <script>
+import dayjs from "dayjs";
 import SlotCalendar from "vue2-slot-calendar";
+// import dayjs from "dayjs";
 
 export default {
 	name: "Calendar",
@@ -52,11 +55,17 @@ export default {
 			format: "yyyy-MM-dd",
 			clear: true,
 			placeholder: "Start Date",
-			width: "440px",
+			width: "345px",
 			firstDayOfWeek: 1,
 			errored: false,
 			loading: true,
 		};
+	},
+	computed: {
+		todayText() {
+			const today = dayjs();
+			return `Today, ${today.format("D MMMM YYYY")}`;
+		}
 	},
 	methods: {
 		redirectToCalendar(e) {
@@ -67,43 +76,53 @@ export default {
 </script>
 
 <style lang="scss">
-.widget-title {
-	margin: 16px 4px;
+.today-text {
+	text-align: center;
+	font-size: 20px;
+	line-height: 30px;
 }
 
 .event-calendar {
-	.datepicker-inner {
-		width: 440px;
+
+	.datepicker-popup {
+		box-shadow: none;
 	}
+
+	.datepicker-inner {
+		width: 345px;
+	}
+
 	.datepicker-body {
 		span {
-			width: 60px;
-			height: 60px;
-			vertical-align: top;
+			width: 45px;
+			height: 45px;
+			// display: flex;
+			// justify-content: center;
+			// align-items: center;
 		}
 
 		span div {
-			cursor: pointer;
+			height: 0;
 		}
 
-		.event-indicator {
-			background-color: rgb(206, 182, 117);
-			position: relative;
-			top: 5px;
-			margin: 0 auto;
-			width: 10px;
-			height: 10px;
-			border-radius: 50%;
-			cursor: pointer;
-		}
+		// .event-indicator {
+		// 	background-color: rgb(206, 182, 117);
+		// 	position: relative;
+		// 	top: 5px;
+		// 	margin: 0 auto;
+		// 	width: 10px;
+		// 	height: 10px;
+		// 	border-radius: 50%;
+		// 	cursor: pointer;
+		// }
 
-		.datepicker-monthRange span {
-			width: 100px;
-			height: 100px;
-			vertical-align: middle;
-			line-height: 100px;
-			// font-weight: 600;
-		}
+		// .datepicker-monthRange span {
+		// 	width: 100px;
+		// 	height: 100px;
+		// 	vertical-align: middle;
+		// 	line-height: 100px;
+		// 	// font-weight: 600;
+		// }
 	}
 }
 </style>

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -106,8 +106,8 @@ export default {
 <style lang="scss">
 .today-text {
 	text-align: center;
-	font-size: 20px;
-	line-height: 30px;
+	font-size: 1.3rem;
+	line-height: 1.8rem;
 }
 
 .event-calendar {

--- a/src/components/UpcomingEventCard.vue
+++ b/src/components/UpcomingEventCard.vue
@@ -172,7 +172,7 @@ export default {
 
 <style lang="scss">
 .event {
-	max-width: 345px;
+	width: 345px;
 	padding: 22px;
 	background: #ffffff;
 	box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);

--- a/src/components/UpcomingEventCard.vue
+++ b/src/components/UpcomingEventCard.vue
@@ -173,11 +173,11 @@ export default {
 <style lang="scss">
 .event {
 	width: 345px;
-	padding: 22px;
+	padding: 1.5rem;
 	background: #ffffff;
 	box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
 	border-radius: 16px;
-	margin-bottom: 16px;
+	margin-bottom: 1rem;
 
 	svg {
 		width: 24px;
@@ -185,16 +185,16 @@ export default {
 	}
 
 	.avatar-container:not(:first-child) {
-		margin-left: -8px;
+		margin-left: -0.5rem;
 	}
 
 	.row {
 		display: flex;
 		align-items: center;
-		margin-bottom: 8px;
+		margin-bottom: 0.5rem;
 
 		span {
-			margin-left: 8px;
+			margin-left: 0.5rem;
 		}
 
 		.title {
@@ -214,7 +214,7 @@ export default {
 	.column {
 		display: flex;
 		flex-direction: column;
-		margin-bottom: 8px;
+		margin-bottom: 0.5rem;
 	}
 
 	.primary {
@@ -237,7 +237,7 @@ export default {
 
 	.description-text {
 		color: #595959;
-		line-height: 15px;
+		line-height: 1rem;
 	}
 
 	.vue-avatar--wrapper span {


### PR DESCRIPTION
The SlotCalendar component was styled a bit unconventional.

See `applyDateStyling()` in `Calendar.vue`

<img width="475" alt="image" src="https://user-images.githubusercontent.com/3958329/173595840-288a7d15-e749-4927-8c3d-1cda270ce0ab.png">

Alignment with assistant logo will be done in other tasks.