### PR TITLE
fix: extraction of events

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ export const EventUtil = {
 	getSecondsSinceMinusOneMonth: (dateByMilliSecs) =>
 		Math.round(dateByMilliSecs / 1000 - EventUtil.oneMonthInSeconds),
 	getObjects: (data) => {
-		const vevents = data[2].slice(1);
+		const vevents = data[2];
 		const veventsData = vevents.map((vevt) => vevt[1]);
 		const recontructedEvents = veventsData.map((vevent) =>
 			vevent.reduce((acc, el) => {


### PR DESCRIPTION
We did unnecessary slice the data object before mapping. The higher parent array has its first element used for classifying the rest of the data like `vevent`. But we don't need it here. Simply removing `.slice(1)` restored the behavior and all events are showing as expected. 🚀