### PR TITLE
check if email and phone are null

### DIFF
--- a/src/components/UpcomingEventCard.vue
+++ b/src/components/UpcomingEventCard.vue
@@ -135,10 +135,10 @@ export default {
 			return links.pop();
 		},
 		email() {
-			return this.description.match(this.emailRegex).pop();
+			return this.description.match(this.emailRegex)?.pop();
 		},
 		phone() {
-			return this.description.match(this.phoneRegex).pop();
+			return this.description.match(this.phoneRegex)?.pop();
 		},
 		safeDescription() {
 			return sanitizeHtml(this.cleanDescription(this.description));


### PR DESCRIPTION
Event card wasn't showing up after I've created a session from the calendar since it had no phone number. This fixes it