### PR TITLE
Fix newsfeed height

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -165,7 +165,6 @@ export default {
 main {
 	background: linear-gradient(180deg, #ffffff 0%, #e3e4f7 100%) !important;
 	width: 100%;
-	min-height: 100vh;
 	padding-top: 1.75rem;
 	display: grid;
 	gap: 1.25rem;

--- a/src/components/Newsfeed.vue
+++ b/src/components/Newsfeed.vue
@@ -117,12 +117,13 @@ export default {
 <style lang="scss" scoped>
 .newsFeed {
 	overflow-y: scroll;
+	min-height: 4rem;
 	max-height: 1080px;
 }
 
-@media (min-height: 1200px) {
+@media (min-height: 1300px) {
 	.newsFeed {
-		max-height: 85vh;
+		max-height: calc(100vh - 13rem);
 	}
 }
 

--- a/src/components/Newsfeed.vue
+++ b/src/components/Newsfeed.vue
@@ -117,7 +117,13 @@ export default {
 <style lang="scss" scoped>
 .newsFeed {
 	overflow-y: scroll;
-	height: 100vh;
+	max-height: 1080px;
+}
+
+@media (min-height: 1200px) {
+	.newsFeed {
+		max-height: 85vh;
+	}
 }
 
 p span {


### PR DESCRIPTION
### Changes

- Makes newsfeed widget the same height as the booking sidebar on screens with less than 1200px height and full screen height on bigger screens

### Testing

- Create 10+ notifications so the newsfeed becomes scrollable. 
- Change the screen zoom scale to see the changes

### Screenshots

![image](https://user-images.githubusercontent.com/29747887/227967681-1762b2e2-a4dd-43c8-b522-cd91e56142a2.png)
![image](https://user-images.githubusercontent.com/29747887/227967699-0557d08f-b9c5-4b46-9be0-58c7f5bf8cab.png)
